### PR TITLE
feat: add keyframe screenshot capture from GSAP timeline labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ node_modules/
 
 ## only ignore in git
 bin/act
+.agents
+skills-lock.json

--- a/cli/displayAdsRecorder.js
+++ b/cli/displayAdsRecorder.js
@@ -20,6 +20,10 @@ const findAdsInDirectory = require("../src/util/findAdsInDirectory");
       new program.Option("-g, --gif [loop]", "If you want to output animated gifs and loop them or play once").choices(['once', 'loop'])
     )
     .option("-m, --mp4", "If you want to output video")
+    .option("-k, --keyframes", "Capture a screenshot at each GSAP timeline label")
+    .addOption(
+      new program.Option("-kf, --keyframe-format <format>", "Image format for keyframe screenshots").choices(['png', 'jpg']).default('png')
+    )
     .option("-au, --audio <relative path to audio file from target dir>", "If you want to add audio")
     .option("-v, --volume <volume>", "When adding audio you can specify volume")
     .addOption(
@@ -53,6 +57,7 @@ const findAdsInDirectory = require("../src/util/findAdsInDirectory");
     { name: "mp4", value: "mp4", checked: false },
     { name: "gif (animated)", value: "gif", checked: false },
     { name: "jpg (last frame)", value: "jpg", checked: false },
+    { name: "keyframes (one per GSAP label)", value: "keyframes", checked: false },
   ]
 
   const gifLoopOptionsMap = {
@@ -67,6 +72,7 @@ const findAdsInDirectory = require("../src/util/findAdsInDirectory");
     gifLoopOptions: gifLoopOptionsMap[options.gif],
     fps: options.fps,
     jpgMaxFileSize: options.jpg,
+    keyframeFormat: options.keyframeFormat,
     audio: options.audio,
     volume: options.volume,
   }
@@ -127,6 +133,17 @@ const findAdsInDirectory = require("../src/util/findAdsInDirectory");
       message: "Please select max KB filesize for backup image",
       when: answers => (adSelection.output.includes("jpg") && adSelection.jpgMaxFileSize === true) || answers.output?.includes("jpg"),
       default: 40,
+    },
+    {
+      type: "list",
+      name: "keyframeFormat",
+      message: "Select image format for keyframe screenshots",
+      choices: [
+        { name: "PNG (lossless)", value: "png" },
+        { name: "JPG (quality 100)", value: "jpg" },
+      ],
+      when: answers => (adSelection.output.includes("keyframes") || answers.output?.includes("keyframes")) && !options.keyframeFormat,
+      default: 0,
     }
   ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mediamonks/display-ads-recorder",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mediamonks/display-ads-recorder",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const addAudioToVideo = require("./util/addAudioToVideo");
 const renderVideo = require("./util/renderVideoFromFiles");
 const getBackupImage = require("./util/getBackupImage");
 const renderGIf = require("./util/renderGifFromVideoFile");
+const captureKeyframes = require("./util/captureKeyframes");
 const cliProgress = require("cli-progress");
 const path = require("path");
 const express = require("express");
@@ -55,6 +56,11 @@ module.exports = async function displayAdsRecorder(options, chunkSize = 10) {
   if (adSelection.output.includes("jpg")) {
     await runWithChunks(recordBackup, "making backup images")
   }
+
+  // if keyframes selected, capture a screenshot at each GSAP timeline label
+  if (adSelection.output.includes("keyframes")) {
+    await runWithChunks(recordKeyframes, "capturing keyframes")
+  }
   
   async function recordScreenshots(adLocation) {
     const [url, htmlBaseDirName] = urlFromAdLocation(adLocation);
@@ -101,6 +107,17 @@ module.exports = async function displayAdsRecorder(options, chunkSize = 10) {
       url,
       outputPathImg,
       maxSizeBytes: adSelection.jpgMaxFileSize * 1024,
+    });
+  }
+
+  async function recordKeyframes(adLocation) {
+    const [url, htmlBaseDirName] = urlFromAdLocation(adLocation);
+
+    await captureKeyframes({
+      url,
+      outputDir: targetDir,
+      adName: htmlBaseDirName,
+      format: adSelection.keyframeFormat || "png",
     });
   }
 

--- a/src/util/captureKeyframes.js
+++ b/src/util/captureKeyframes.js
@@ -1,0 +1,258 @@
+const puppeteer = require("puppeteer");
+const path = require("path");
+const fs = require("fs-extra");
+const minimal_args = require("../data/minimalArgs");
+
+function sanitizeLabelName(name) {
+  return name.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+module.exports = async function captureKeyframes({
+  url,
+  outputDir,
+  adName,
+  format = "png",
+  timeout = 60000,
+}) {
+  const launchOptions = {
+    headless: true,
+    args: [
+      ...minimal_args,
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+      "--disable-dev-shm-usage",
+      "--disable-gpu",
+      "--disable-web-security",
+    ],
+    ignoreHTTPSErrors: true,
+    defaultViewport: null,
+    protocolTimeout: 30000,
+  };
+
+  return new Promise(async (resolve, reject) => {
+    let browser;
+    let isClosing = false;
+    let timeoutId;
+    let lastActivity = Date.now();
+
+    function resetTimeout() {
+      lastActivity = Date.now();
+      if (timeoutId) clearTimeout(timeoutId);
+      timeoutId = setTimeout(async () => {
+        const elapsed = Date.now() - lastActivity;
+        console.error(
+          `\n[Error] Keyframe capture timed out for "${adName}" ` +
+            `after ${Math.round(elapsed / 1000)}s of inactivity ` +
+            `(captured ${capturedFiles.length}/${labels.length} labels)`
+        );
+        if (!isClosing) {
+          isClosing = true;
+          try { await browser.close(); } catch (e) { /* ignore */ }
+        }
+        resolve(capturedFiles); // resolve with whatever we got, don't block the batch
+      }, timeout);
+    }
+
+    async function cleanup() {
+      if (timeoutId) clearTimeout(timeoutId);
+      if (!isClosing) {
+        isClosing = true;
+        try { await browser.close(); } catch (e) { /* ignore */ }
+      }
+    }
+
+    try {
+      browser = await puppeteer.launch(launchOptions);
+    } catch (err) {
+      console.error("[Error] Browser launch failed:", err);
+      return reject(err);
+    }
+
+    const page = await browser.newPage();
+
+    let labels = [];
+    let currentLabelIndex = 0;
+    const capturedFiles = [];
+
+    page.on("error", async (err) => {
+      console.error(`[Error] Page crashed for "${adName}":`, err);
+      await cleanup();
+      reject(err);
+    });
+
+    page.on("close", () => {
+      if (!isClosing) {
+        console.error(`\n[Error] Page unexpectedly closed for "${adName}"`);
+        cleanup();
+        resolve(capturedFiles);
+      }
+    });
+
+    browser.on("disconnected", () => {
+      if (!isClosing) {
+        console.error(`\n[Error] Browser disconnected for "${adName}"`);
+        if (timeoutId) clearTimeout(timeoutId);
+        resolve(capturedFiles);
+      }
+    });
+
+    await page.exposeFunction("onMessageReceivedEvent", async (e) => {
+      resetTimeout();
+      switch (e.data.name) {
+        case "animation-ready":
+          await handleAnimationReady(e.data);
+          break;
+
+        case "current-frame":
+          await captureCurrentLabel();
+          break;
+      }
+    });
+
+    function parseLabels(raw) {
+      if (!raw) return [];
+      let parsed = [];
+      // Handle object format: { "start": 0, "frame1": 3, ... }
+      if (!Array.isArray(raw) && typeof raw === "object") {
+        parsed = Object.entries(raw).map(([name, time]) => ({ name, time }));
+      }
+      // Handle array format: [{ name: "start", time: 0 }, ...]
+      else if (Array.isArray(raw)) {
+        parsed = raw;
+      }
+      return sortAndFilterLabels(parsed);
+    }
+
+    function sortAndFilterLabels(labels) {
+      if (!labels.length) return labels;
+
+      // Sort by time so labels are in timeline order
+      labels.sort((a, b) => a.time - b.time);
+
+      // Skip any label at time 0 — the animation hasn't built
+      // the first frame yet at t=0, so it would be an empty image.
+      // The first meaningful keyframe is the label where the first
+      // frame finishes constructing (e.g. "frame1" at t=3).
+      labels = labels.filter((label) => label.time > 0);
+
+      return labels;
+    }
+
+    async function getLabelsFromPage() {
+      return page.evaluate(() => {
+        if (typeof gsap === "undefined") return null;
+
+        // Walk GSAP's global timeline tree to find timelines with labels
+        function findLabels(tl) {
+          if (tl.labels && Object.keys(tl.labels).length > 0) {
+            return tl.labels;
+          }
+          const children = tl.getChildren
+            ? tl.getChildren(false, false, true)
+            : [];
+          for (const child of children) {
+            const found = findLabels(child);
+            if (found) return found;
+          }
+          return null;
+        }
+
+        return findLabels(gsap.globalTimeline);
+      });
+    }
+
+    async function handleAnimationReady(animationInfo) {
+      // Try labels from message first, fallback to querying GSAP on the page
+      labels = parseLabels(animationInfo.labels);
+
+      if (!labels.length) {
+        const pageLabels = await getLabelsFromPage();
+        labels = parseLabels(pageLabels);
+      }
+
+      if (!labels.length) {
+        console.warn(
+          `\n[Warning] No GSAP timeline labels found for "${adName}". ` +
+            "Make sure the ad has a GSAP timeline with labels (e.g. 'start', 'frame1', etc.)."
+        );
+        await cleanup();
+        return resolve(capturedFiles);
+      }
+
+      const deviceScaleFactor = await page.evaluate("window.devicePixelRatio");
+
+      await page.setViewport({
+        width: animationInfo.width,
+        height: animationInfo.height,
+        deviceScaleFactor,
+      });
+
+      console.log(
+        `\nCapturing ${labels.length} keyframe(s) for "${adName}": ${labels.map((l) => l.name).join(", ")}`
+      );
+
+      // Request the first label's frame
+      await dispatchEventToPage(page, {
+        name: "request-goto-frame",
+        frame: labels[0].time * 1000,
+      });
+    }
+
+    async function captureCurrentLabel() {
+      try {
+        const label = labels[currentLabelIndex];
+        const sanitizedName = sanitizeLabelName(label.name);
+        const ext = format === "jpg" ? "jpg" : "png";
+        const filename = `${adName}_${sanitizedName}.${ext}`;
+        const outputPath = path.join(outputDir, filename);
+
+        const screenshotOptions =
+          format === "jpg"
+            ? { path: outputPath, type: "jpeg", quality: 100 }
+            : { path: outputPath, type: "png" };
+
+        await page.screenshot(screenshotOptions);
+        capturedFiles.push(outputPath);
+
+        currentLabelIndex++;
+        process.stdout.write(
+          `\r  [${adName}] ${currentLabelIndex}/${labels.length} keyframes captured`
+        );
+
+        if (currentLabelIndex < labels.length) {
+          await dispatchEventToPage(page, {
+            name: "request-goto-frame",
+            frame: labels[currentLabelIndex].time * 1000,
+          });
+        } else {
+          process.stdout.write("\n");
+          await cleanup();
+          resolve(capturedFiles);
+        }
+      } catch (error) {
+        console.error(`\n[Error] Failed to capture keyframe for "${adName}":`, error);
+        await cleanup();
+        reject(error);
+      }
+    }
+
+    async function dispatchEventToPage(page, data) {
+      await page.evaluate(function (data) {
+        window.postMessage(data);
+      }, data);
+    }
+
+    function listenFor(page, type) {
+      return page.evaluateOnNewDocument((type) => {
+        window.addEventListener(type, (e) => {
+          window.onMessageReceivedEvent({ type, data: e.data });
+        });
+      }, type);
+    }
+
+    await listenFor(page, "message");
+
+    resetTimeout(); // start the inactivity timer
+    await page.goto(url);
+  });
+};


### PR DESCRIPTION
## Summary

Adds a new `--keyframes` output option to the recorder that captures a high-quality static screenshot at each settled keyframe in the GSAP timeline. Useful for creative review, storyboarding, and deliverables that require individual frame states.

## What's new

- **`--keyframes` (`-k`)** — new CLI flag to enable keyframe capture
- **`--keyframe-format` (`-kf`)** — choose `png` (lossless, default) or `jpg` (quality 100)
- **Interactive support** — "keyframes (one per GSAP label)" appears in the output selection menu with a follow-up format prompt

## How it works

1. The recorder loads the ad in a headless browser and waits for the `animation-ready` event
2. Timeline labels are detected automatically — either from the message payload or by querying `gsap.globalTimeline` directly on the page
3. Labels at `time === 0` are skipped (the animation hasn't settled yet at that point)
4. For each remaining label, the recorder seeks to that timestamp and captures a full-resolution screenshot
5. Output files are saved as `{adName}_{labelName}.png` (or `.jpg`) in the target directory

### Example

Timeline: `start (t=0) → frame1 (t=3) → frame2 (t=4.5) → frame3 (t=6) → end (t=7)`

Output (start skipped):
- `banner_300x250_frame1.png`
- `banner_300x250_frame2.png`
- `banner_300x250_frame3.png`
- `banner_300x250_end.png`

## Reliability

- 60-second inactivity timeout per ad — prevents hanging when running parallel captures
- Browser disconnect and page crash handlers with graceful fallback
- Per-frame progress logging in the terminal

## Files changed

| File | Change |
|------|--------|
| `src/util/captureKeyframes.js` | **New** — Puppeteer-based keyframe capture utility |
| `cli/displayAdsRecorder.js` | Added `--keyframes`, `--keyframe-format` flags and inquirer prompts |
| `src/index.js` | Added keyframes pipeline branch and `captureKeyframes` integration |
| `recorder.md` | Updated documentation covering all output formats |

## Notes

- Works without any changes to `@mediamonks/display-temple` — labels are queried directly from GSAP on the page as a fallback
- Accepts any label naming convention (frame0, Frame1, keyframe_1, etc.)
- Can be combined with other outputs (`--keyframes --mp4 --gif`)